### PR TITLE
lazy loading to useswr so note content loads

### DIFF
--- a/src/components/views/headers/CollaborationModal.tsx
+++ b/src/components/views/headers/CollaborationModal.tsx
@@ -81,7 +81,7 @@ export default function CollaborationModal({
   }, [email]);
 
   const { data: collaborators = [], isLoading } = useSWR(
-    currentNote?._id ? `collaborators-${currentNote._id}` : null,
+    isOpen && currentNote?._id ? `collaborators-${currentNote._id}` : null,
     async () => {
       if (!currentNote?._id) return [];
       const collaborators = await dataFetchers.fetchSharedUsers(


### PR DESCRIPTION
- collaborative notes would take a second to load even though note contents are in memory
- changed useswr call to lazyload the collaborators so note content is accessible asap but collaborators can take a second